### PR TITLE
Fix problem with ! and ?

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ import quotesDB from 'typographic-quotes-l10n-db';
 
 export default (input, {locale = 'en-us'} = {})=> {
   const localeQuotes = quotesDB[locale];
-  const pattern = /(^|\s)(?:"(.*?)"|'(.*?)')(\s|$|\.|,)/gim;
+  const pattern = /(^|\s)(?:"(.*?)"|'(.*?)')(\s|$|\.|,|\?|!)/gim;
 
   const primary = (match, before='', part1='', part2='', after='')=> {
     const quotes = [localeQuotes[0], localeQuotes[1]];


### PR DESCRIPTION
Small but important fix.

If you try to process strings with `!` or `?` then you'll see that nothing happends:

```
Hello, "world"! --> Hello, "world"!
Hello, "world"? --> Hello, "world"!
```

It works only for `.` and `,`. This request fixes that problem.
