### PR TITLE
Add support for some new kinds of punctuation

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,14 +5,13 @@ export default function typographicQuotes(input = '', { locale } = {}) {
     return input;
   }
   const localeQuotes = db[locale];
-  let separator = '';
+  const separator = locale === 'fr' ? ' ' : '';
 
   const pattern = /(?<=^|\s|[\[(\-–—])(?:"(.*?)"|'(.*?)')(?=$|\s|[.,:;?!…\])\-–—])/gim;
   const handleQuotes = (quotes, cb) =>
     (match, part1='', part2='') => {
       let text = (part1 + part2);
       if (cb) { text = text.replace(pattern, cb); }
-      if (locale === 'fr') { separator = ' '; }
       return `${quotes[0]}${separator}${text}${separator}${quotes[1]}`;
     }
 

--- a/index.js
+++ b/index.js
@@ -7,13 +7,13 @@ export default function typographicQuotes(input = '', { locale } = {}) {
   const localeQuotes = db[locale];
   let separator = '';
 
-  const pattern = /(^|\s|[\[(])(?:"(.*?)"|'(.*?)')(\s|$|[.,:;?!…\])])/gim;
+  const pattern = /(?<=^|\s|[\[(\-–—])(?:"(.*?)"|'(.*?)')(?=$|\s|[.,:;?!…\])\-–—])/gim;
   const handleQuotes = (quotes, cb) =>
-    (match, before='', part1='', part2='', after='') => {
+    (match, part1='', part2='') => {
       let text = (part1 + part2);
       if (cb) { text = text.replace(pattern, cb); }
       if (locale === 'fr') { separator = ' '; }
-      return `${before}${quotes[0]}${separator}${text}${separator}${quotes[1]}${after}`;
+      return `${quotes[0]}${separator}${text}${separator}${quotes[1]}`;
     }
 
   return input.replace(pattern,

--- a/index.js
+++ b/index.js
@@ -7,12 +7,12 @@ export default function typographicQuotes(input = '', { locale } = {}) {
   const localeQuotes = db[locale];
   const separator = locale === 'fr' ? ' ' : '';
 
-  const pattern = /(?<=^|\s|[\[(\-–—])(?:"(.*?)"|'(.*?)')(?=$|\s|[.,:;?!…\])\-–—])/gim;
+  const pattern = /(^|\s|[\[(\-–—])(?:"(.*?)"|'(.*?)')(?=$|\s|[.,:;?!…\])\-–—])/gim;
   const handleQuotes = (quotes, cb) =>
-    (match, part1='', part2='') => {
+    (match, before='', part1='', part2='') => {
       let text = (part1 + part2);
       if (cb) { text = text.replace(pattern, cb); }
-      return `${quotes[0]}${separator}${text}${separator}${quotes[1]}`;
+      return `${before}${quotes[0]}${separator}${text}${separator}${quotes[1]}`;
     }
 
   return input.replace(pattern,

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ export default function typographicQuotes(input = '', { locale } = {}) {
   const localeQuotes = db[locale];
   let separator = '';
 
-  const pattern = /(^|\s)(?:"(.*?)"|'(.*?)')(\s|$|\.|,|\?|!)/gim;
+  const pattern = /(^|\s|[\[(])(?:"(.*?)"|'(.*?)')(\s|$|[.,?!…\])])/gim;
   const handleQuotes = (quotes, cb) =>
     (match, before='', part1='', part2='', after='') => {
       let text = (part1 + part2);

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ export default function typographicQuotes(input = '', { locale } = {}) {
   const localeQuotes = db[locale];
   let separator = '';
 
-  const pattern = /(^|\s|[\[(])(?:"(.*?)"|'(.*?)')(\s|$|[.,?!…\])])/gim;
+  const pattern = /(^|\s|[\[(])(?:"(.*?)"|'(.*?)')(\s|$|[.,:;?!…\])])/gim;
   const handleQuotes = (quotes, cb) =>
     (match, before='', part1='', part2='', after='') => {
       let text = (part1 + part2);

--- a/test.js
+++ b/test.js
@@ -69,6 +69,12 @@ it('should fix quotes immediately surroundedy by parens', () =>
 it('should fix quotes surrounded by square brackets', () =>
   equal(quotes(`["foo bar baz"]`, american), `[“foo bar baz”]`));
 
+it('should fix quotes followed by a semicolon', () =>
+  equal(quotes(`foo "bar"; baz`, american), `foo “bar”; baz`));
+
+it('should fix quotes followed by a colon', () =>
+  equal(quotes(`foo "bar": baz`, american), `foo “bar”: baz`));
+
 it('should fix quotes followed by several dots', () =>
   equal(quotes(`foo "bar"... baz`, american), `foo “bar”... baz`));
 

--- a/test.js
+++ b/test.js
@@ -53,3 +53,9 @@ it('should fix nested quotes in end', () =>
 
 it('should not change apostrophes', () =>
   equal(quotes(`I'm not changing apostrophes`, american), `I'm not changing apostrophes`));
+
+it('should fix quotes followed by several dots', () =>
+  equal(quotes(`foo "bar"... baz`, american), `foo “bar”... baz`));
+
+it('should fix quotes followed by an ellipsis', () =>
+  equal(quotes(`foo "bar"… baz`, american), `foo “bar”… baz`));

--- a/test.js
+++ b/test.js
@@ -54,6 +54,21 @@ it('should fix nested quotes in end', () =>
 it('should not change apostrophes', () =>
   equal(quotes(`I'm not changing apostrophes`, american), `I'm not changing apostrophes`));
 
+it('should fix quotes preceded by a paren', () =>
+  equal(quotes(`("foo" bar baz)`, american), `(“foo” bar baz)`));
+
+it('should fix quotes followed by a paren', () =>
+  equal(quotes(`(foo bar "baz")`, american), `(foo bar “baz”)`));
+
+it('should fix quotes inside parens', () =>
+  equal(quotes(`(foo "bar" baz)`, american), `(foo “bar” baz)`));
+
+it('should fix quotes immediately surroundedy by parens', () =>
+  equal(quotes(`("foo bar baz")`, american), `(“foo bar baz”)`));
+
+it('should fix quotes surrounded by square brackets', () =>
+  equal(quotes(`["foo bar baz"]`, american), `[“foo bar baz”]`));
+
 it('should fix quotes followed by several dots', () =>
   equal(quotes(`foo "bar"... baz`, american), `foo “bar”... baz`));
 

--- a/test.js
+++ b/test.js
@@ -80,3 +80,18 @@ it('should fix quotes followed by several dots', () =>
 
 it('should fix quotes followed by an ellipsis', () =>
   equal(quotes(`foo "bar"… baz`, american), `foo “bar”… baz`));
+
+it('should fix quotes preceded by a hyphen', () =>
+  equal(quotes(`anti-"foo"`, american), `anti-“foo”`));
+
+it('should fix quotes followed by a hyphen', () =>
+  equal(quotes(`"foo"-ish`, american), `“foo”-ish`));
+
+it('should fix quotes around hyphens', () =>
+  equal(quotes(`"foo"-"bar"`, american), `“foo”-“bar”`));
+
+it('should fix quotes near en-dashes', () =>
+  equal(quotes(`"foo"–"bar"`, american), `“foo”–“bar”`));
+
+it('should fix quotes near em-dashes', () =>
+  equal(quotes(`"foo"—"bar"`, american), `“foo”—“bar”`));


### PR DESCRIPTION
Hello!

I've been using this library with [remark-textr](https://github.com/remarkjs/remark-textr) for a while and noticed that there were a few edge cases where straight quotes weren't being converted to curly quotes. For example (using the `en-us` locale):

| Input | Expected output | Actual output |
|------|---------|-------|
| `("u" is written as "o" in spelling)` | `(“u” is written as “o” in spelling)` | `("u" is written as “o” in spelling)` |
| `a very "foo"-ish concept` | `a very “foo”-ish concept` | `a very "foo"-ish concept` |
| `not "nothing"; but...` | `not “nothing”; but...` | `not "nothing"; but...` |

This pull request fixes a few cases like this. Specifically it adds support for:
- quotes preceded by `(` or `[`, or followed by `)` or `]`
- quotes followed by `;` or `:`
- quotes followed by `…` (U+2026 HORIZONTAL ELLIPSIS)
- quotes preceded or followed by hyphens, en dashes, or em dashes

I've added tests for each of these cases.

Let me know if you have thoughts or want me to make any changes.

Thanks!